### PR TITLE
Add support for --dry-run

### DIFF
--- a/bin/dart_doc_syncer.dart
+++ b/bin/dart_doc_syncer.dart
@@ -3,15 +3,23 @@ import 'dart:async';
 import 'package:logging/logging.dart';
 
 import 'package:dart_doc_syncer/documentation_updater.dart';
+import 'package:dart_doc_syncer/options.dart';
 
 /// Syncs an example application living in the angular.io repository to a
 /// dedicated repository that will contain a generated cleaned-up version.
 ///
-///     dart_doc_syncer <examplePath> <exampleRepository>
-Future main(List<String> args) async {
-  Logger.root.level = Level.WARNING;
+///     dart_doc_syncer [-n|-h] <examplePath> <exampleRepository>
+Future main(List<String> _args) async {
+  var args = processArgs(_args);
+  if (args.length != 2)
+    printUsageAndExit("Expected 2 arguments but found ${args.length}");
+
+
+  Logger.root.level = dryRun ? Level.ALL : Level.WARNING;
   Logger.root.onRecord.listen((LogRecord rec) {
-    print('${rec.level.name}: ${rec.time}: ${rec.message}');
+    var msg = '${rec.message}';
+    if (!dryRun) msg = '${rec.level.name}: ${rec.time}: ' + msg;
+    print(msg);
   });
 
   final path = args[0];

--- a/lib/options.dart
+++ b/lib/options.dart
@@ -1,0 +1,1 @@
+export 'src/options.dart';

--- a/lib/src/generate_doc.dart
+++ b/lib/src/generate_doc.dart
@@ -7,6 +7,8 @@ import 'package:path/path.dart' as p;
 import 'package:dart_doc_syncer/src/generate_readme.dart';
 import 'package:dart_doc_syncer/src/remove_doc_tags.dart';
 
+import 'runner.dart' as Process; // TODO(chalin) tmp name to avoid code changes
+
 final Logger _logger = new Logger('update_doc_repo');
 
 final String _basePath = p.dirname(Platform.script.path);
@@ -34,20 +36,22 @@ Future assembleDocumentationExample(Directory snapshot, Directory out,
   ]);
 
   // Clean the application code
-  _logger.fine('Removing doc tags in $out.path.');
+  _logger.fine('Removing doc tags in ${out.path}.');
   await _removeDocTagsFromApplication(out.path);
 
   // Generate a README file
   generateReadme(out.path, angularIoPath: angularIoPath);
 
   // Format the Dart code
-  _logger.fine('Running dartfmt in $out.path.');
+  _logger.fine('Running dartfmt in ${out.path}.');
   await Process.run('dartfmt', ['-w', p.absolute(out.path)]);
 }
 
 /// Rewrites all files under the [path] directory by filtering out the
 /// documentation tags.
 Future _removeDocTagsFromApplication(String path) async {
+  if (Process.dryRun) return new Future.value(null);
+
   final files = await new Directory(path)
       .list(recursive: true)
       .where((e) => e is File)

--- a/lib/src/generate_gh_pages.dart
+++ b/lib/src/generate_gh_pages.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
+import 'runner.dart' as Process; // TODO(chalin) tmp name to avoid code changes
+
 final String _basePath = p.dirname(Platform.script.path);
 
 /// Returns the path to the folder where the application assets have been

--- a/lib/src/generate_readme.dart
+++ b/lib/src/generate_readme.dart
@@ -2,7 +2,12 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
+
+import 'options.dart';
+
+final Logger _logger = new Logger('generateReadme');
 
 /// Generates a README file for the example at [path].
 Future generateReadme(String path, {String angularIoPath}) async {
@@ -73,6 +78,8 @@ If you find a problem with this sample's code, please open an
 ''';
 
   final readmeFile = new File(p.join(path, 'README.md'));
+  _logger.fine('Generating $readmeFile.');
+  if (dryRun) return new Future.value(null);
   await readmeFile.writeAsStringSync(readmeContent);
 }
 

--- a/lib/src/git_repository.dart
+++ b/lib/src/git_repository.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
+import 'runner.dart' as Process; // TODO(chalin) tmp name to avoid code changes
+
 class GitRepositoryFactory {
   GitRepository create(String directory) => new GitRepository(directory);
 }
@@ -98,6 +100,8 @@ class GitRepository {
 
   /// Returns the commit hash at HEAD.
   Future<String> getCommitHash({bool short: false}) async {
+    if (Process.dryRun) return new Future.value(null);
+
     final args = "rev-parse${short ? ' --short' : ''} HEAD".split(' ');
     final hash = await _assertSuccess(
         () => Process.run('git', args, workingDirectory: directory));

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+
+/// Global option
+bool dryRun = true;
+var _parser;
+
+/// Processes command line options and returns remaining arguments.
+List<String> processArgs(List<String> args) {
+  _parser = new ArgParser(allowTrailingOptions: true);
+
+  _parser.addFlag("help",
+      abbr: "h", negatable: false, help: "Shows usage information.");
+  const dryRunMsg = "Show which commands would be executed but make (almost) "
+      "no changes. (Only the temporary directory will be created and deleted.)";
+  _parser.addFlag("dry-run", abbr: "n", negatable: false, help: dryRunMsg);
+
+  var argResults;
+  try {
+    argResults = _parser.parse(args);
+  } on FormatException catch (e) {
+    printUsageAndExit(e.message, 0);
+  }
+
+  if (argResults["help"]) printUsageAndExit(_parser);
+
+  dryRun = argResults['dry-run'];
+  return argResults.rest;
+}
+
+void printUsageAndExit([String _msg, int exitCode = 1]) {
+  var msg = "Syncs angular.io example applications.";
+  if (_msg != null) msg = _msg;
+  print('''
+
+$msg.
+
+Usage: ${Platform.script} [options] <examplePath> <exampleRepository>
+
+${_parser != null ? _parser.usage : ''}
+''');
+  exit(exitCode);
+}

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:logging/logging.dart';
+import 'options.dart';
+
+export 'options.dart' show dryRun;
+
+final Logger _logger = new Logger('runner');
+
+Future<ProcessResult> run(String executable, List<String> arguments,
+    {String workingDirectory}) {
+  if (!dryRun)
+    return Process.run(executable, arguments,
+        workingDirectory: workingDirectory);
+
+  var message = "  > $executable ${arguments.join(' ')}";
+  if (workingDirectory != null) message += " ($workingDirectory)";
+  _logger.finest(message);
+  if (executable == 'git' && arguments[0] == 'clone') {
+    var path = arguments[2];
+    new Directory(path).createSync(recursive: true);
+  }
+  const int _bogusPid = 0;
+  const int _exitOk = 0;
+  return new Future.value(new ProcessResult(_bogusPid, _exitOk, null, null));
+}


### PR DESCRIPTION
Made **minimal** changes to support performing a dry run. As shown by the sample output below, descriptions of the steps are followed by the exact commands executed (lines prefixed with `>`).

Given the level of detail in the output, support for `--dry-run` was only added to `dart_doc_syncer` and not `sync_all`.

(The new `options.dart` file is a bit long but it was just as easy to borrow `ArgParser` usage code from elsewhere than to hand craft the processing.)

```
Cloning https://github.com/angular/angular.io into ~/git/dart-doc-syncer/bin/.tmp/angular_io.
  > git clone https://github.com/angular/angular.io ~/git/dart-doc-syncer/bin/.tmp/angular_io
Cloning git@github.com:angular-examples/architecture.git into ~/git/dart-doc-syncer/bin/.tmp/architecture.
  > git clone git@github.com:angular-examples/architecture.git ~/git/dart-doc-syncer/bin/.tmp/architecture
Deleting all the repository content in ~/git/dart-doc-syncer/bin/.tmp/architecture.
  > git rm * (~/git/dart-doc-syncer/bin/.tmp/architecture)
Generating updated example application into ~/git/dart-doc-syncer/bin/.tmp/architecture.
  > cp -a ~/git/dart-doc-syncer/bin/../default_assets/. ~/git/dart-doc-syncer/bin/.tmp/architecture
  > cp -a ~/git/dart-doc-syncer/bin/.tmp/angular_io/public/docs/_examples/architecture/dart/. ~/git/dart-doc-syncer/bin/.tmp/architecture
  > rm ~/git/dart-doc-syncer/bin/.tmp/architecture/.analysis_options
  > cp ~/git/dart-doc-syncer/bin/.tmp/angular_io/public/docs/_examples/styles.css ~/git/dart-doc-syncer/bin/.tmp/architecture/web/styles.css
Removing doc tags in ~/git/dart-doc-syncer/bin/.tmp/architecture.
Running dartfmt in ~/git/dart-doc-syncer/bin/.tmp/architecture.
  > dartfmt -w ~/git/dart-doc-syncer/bin/.tmp/architecture
Checkout master.
  > git checkout master (~/git/dart-doc-syncer/bin/.tmp/architecture)
Staging local changes for ~/git/dart-doc-syncer/bin/.tmp/architecture.
  > git add . (~/git/dart-doc-syncer/bin/.tmp/architecture)
Comitting changes for ~/git/dart-doc-syncer/bin/.tmp/architecture.
  > git commit -m Sync with null
```
