### PR TITLE
Add support for: example name as single arg and --verbose

### DIFF
--- a/bin/dart_doc_syncer.dart
+++ b/bin/dart_doc_syncer.dart
@@ -3,15 +3,23 @@ import 'dart:async';
 import 'package:logging/logging.dart';
 
 import 'package:dart_doc_syncer/documentation_updater.dart';
+import 'package:dart_doc_syncer/options.dart';
 
 /// Syncs an example application living in the angular.io repository to a
 /// dedicated repository that will contain a generated cleaned-up version.
 ///
-///     dart_doc_syncer <examplePath> <exampleRepository>
-Future main(List<String> args) async {
-  Logger.root.level = Level.WARNING;
+///     dart_doc_syncer [-n|-h] <examplePath> <exampleRepository>
+Future main(List<String> _args) async {
+  var args = processArgs(_args);
+  if (args.length != 2)
+    printUsageAndExit("Expected 2 arguments but found ${args.length}");
+
+
+  Logger.root.level = dryRun ? Level.ALL : Level.WARNING;
   Logger.root.onRecord.listen((LogRecord rec) {
-    print('${rec.level.name}: ${rec.time}: ${rec.message}');
+    var msg = '${rec.message}';
+    if (!dryRun) msg = '${rec.level.name}: ${rec.time}: ' + msg;
+    print(msg);
   });
 
   final path = args[0];

--- a/bin/dart_doc_syncer.dart
+++ b/bin/dart_doc_syncer.dart
@@ -9,7 +9,7 @@ import 'package:dart_doc_syncer/options.dart';
 /// Syncs an example application living in the angular.io repository to a
 /// dedicated repository that will contain a generated cleaned-up version.
 ///
-///  dart_doc_syncer [-h|-n|-v] [<exampleName> | <examplePath> <exampleRepo>]
+///    dart_doc_syncer [-h|-n|-v] [<exampleName> | <examplePath> <exampleRepo>]
 Future main(List<String> _args) async {
   var args = processArgs(_args);
   Logger.root.level = dryRun || verbose ? Level.ALL : Level.WARNING;

--- a/bin/dart_doc_syncer.dart
+++ b/bin/dart_doc_syncer.dart
@@ -3,30 +3,40 @@ import 'dart:async';
 import 'package:logging/logging.dart';
 
 import 'package:dart_doc_syncer/documentation_updater.dart';
+import 'package:dart_doc_syncer/example2uri.dart';
 import 'package:dart_doc_syncer/options.dart';
 
 /// Syncs an example application living in the angular.io repository to a
 /// dedicated repository that will contain a generated cleaned-up version.
 ///
-///     dart_doc_syncer [-n|-h] <examplePath> <exampleRepository>
+///  dart_doc_syncer [-h|-n|-v] [<exampleName> | <examplePath> <exampleRepo>]
 Future main(List<String> _args) async {
   var args = processArgs(_args);
-  if (args.length != 2)
-    printUsageAndExit("Expected 2 arguments but found ${args.length}");
-
-
-  Logger.root.level = dryRun ? Level.ALL : Level.WARNING;
+  Logger.root.level = dryRun || verbose ? Level.ALL : Level.WARNING;
   Logger.root.onRecord.listen((LogRecord rec) {
     var msg = '${rec.message}';
     if (!dryRun) msg = '${rec.level.name}: ${rec.time}: ' + msg;
     print(msg);
   });
 
-  final path = args[0];
-  final repository = args[1];
+  var path, repositoryUri;
+  switch (args.length) {
+    case 1:
+      var e2u = new Example2Uri(args[0]);
+      path = e2u.path;
+      repositoryUri = e2u.repositoryUri;
+      break;
+    case 2:
+      path = args[0];
+      repositoryUri = args[1];
+      break;
+    default:
+      printUsageAndExit("Expected 1 or 2 arguments but found ${args.length}");
+    // #NotReached
+  }
 
   final documentation = new DocumentationUpdater();
-  await documentation.updateRepository(path, repository);
+  await documentation.updateRepository(path, repositoryUri);
 
-  print('Done updating $repository');
+  print('Done updating $repositoryUri');
 }

--- a/lib/example2uri.dart
+++ b/lib/example2uri.dart
@@ -1,0 +1,10 @@
+class Example2Uri {
+  final String _exampleName;
+
+  Example2Uri(this._exampleName);
+
+  String get path => 'public/docs/_examples/$_exampleName/dart';
+
+  String get repositoryUri =>
+      'git@github.com:angular-examples/$_exampleName.git';
+}

--- a/lib/options.dart
+++ b/lib/options.dart
@@ -1,0 +1,1 @@
+export 'src/options.dart';

--- a/lib/src/generate_doc.dart
+++ b/lib/src/generate_doc.dart
@@ -7,6 +7,8 @@ import 'package:path/path.dart' as p;
 import 'package:dart_doc_syncer/src/generate_readme.dart';
 import 'package:dart_doc_syncer/src/remove_doc_tags.dart';
 
+import 'runner.dart' as Process; // TODO(chalin) tmp name to avoid code changes
+
 final Logger _logger = new Logger('update_doc_repo');
 
 final String _basePath = p.dirname(Platform.script.path);
@@ -34,20 +36,22 @@ Future assembleDocumentationExample(Directory snapshot, Directory out,
   ]);
 
   // Clean the application code
-  _logger.fine('Removing doc tags in $out.path.');
+  _logger.fine('Removing doc tags in ${out.path}.');
   await _removeDocTagsFromApplication(out.path);
 
   // Generate a README file
   generateReadme(out.path, angularIoPath: angularIoPath);
 
   // Format the Dart code
-  _logger.fine('Running dartfmt in $out.path.');
+  _logger.fine('Running dartfmt in ${out.path}.');
   await Process.run('dartfmt', ['-w', p.absolute(out.path)]);
 }
 
 /// Rewrites all files under the [path] directory by filtering out the
 /// documentation tags.
 Future _removeDocTagsFromApplication(String path) async {
+  if (Process.dryRun) return new Future.value(null);
+
   final files = await new Directory(path)
       .list(recursive: true)
       .where((e) => e is File)

--- a/lib/src/generate_gh_pages.dart
+++ b/lib/src/generate_gh_pages.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
+import 'runner.dart' as Process; // TODO(chalin) tmp name to avoid code changes
+
 final String _basePath = p.dirname(Platform.script.path);
 
 /// Returns the path to the folder where the application assets have been

--- a/lib/src/generate_readme.dart
+++ b/lib/src/generate_readme.dart
@@ -2,7 +2,12 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
+
+import 'options.dart';
+
+final Logger _logger = new Logger('generateReadme');
 
 /// Generates a README file for the example at [path].
 Future generateReadme(String path, {String angularIoPath}) async {
@@ -73,6 +78,8 @@ If you find a problem with this sample's code, please open an
 ''';
 
   final readmeFile = new File(p.join(path, 'README.md'));
+  _logger.fine('Generating $readmeFile.');
+  if (dryRun) return new Future.value(null);
   await readmeFile.writeAsStringSync(readmeContent);
 }
 

--- a/lib/src/generate_readme.dart
+++ b/lib/src/generate_readme.dart
@@ -27,7 +27,7 @@ Future generateReadme(String path, {String angularIoPath}) async {
 Future _generateReadme(String path, SyncData syncData) async {
   final warningMessage = (syncData.docHref == null)
       ? '''
-**WARNING:** This example is preliminary and will probably change.
+**WARNING:** This example is preliminary and subject to change.
 
 ------------------------------------------------------------------
       '''

--- a/lib/src/git_repository.dart
+++ b/lib/src/git_repository.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
+import 'runner.dart' as Process; // TODO(chalin) tmp name to avoid code changes
+
 class GitRepositoryFactory {
   GitRepository create(String directory) => new GitRepository(directory);
 }
@@ -98,6 +100,8 @@ class GitRepository {
 
   /// Returns the commit hash at HEAD.
   Future<String> getCommitHash({bool short: false}) async {
+    if (Process.dryRun) return new Future.value(null);
+
     final args = "rev-parse${short ? ' --short' : ''} HEAD".split(' ');
     final hash = await _assertSuccess(
         () => Process.run('git', args, workingDirectory: directory));

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -4,17 +4,19 @@ import 'package:args/args.dart';
 
 /// Global option
 bool dryRun = true;
-var _parser;
+bool verbose = false;
+ArgParser _parser;
 
 /// Processes command line options and returns remaining arguments.
 List<String> processArgs(List<String> args) {
   _parser = new ArgParser(allowTrailingOptions: true);
 
-  _parser.addFlag("help",
-      abbr: "h", negatable: false, help: "Shows usage information.");
-  const dryRunMsg = "Show which commands would be executed but make (almost) "
-      "no changes. (Only the temporary directory will be created and deleted.)";
-  _parser.addFlag("dry-run", abbr: "n", negatable: false, help: dryRunMsg);
+  _parser.addFlag('help',
+      abbr: 'h', negatable: false, help: 'Shows usage information.');
+  const dryRunMsg = 'Show which commands would be executed but make (almost) '
+      'no changes. (Only the temporary directory will be created and deleted.)';
+  _parser.addFlag('dry-run', abbr: 'n', negatable: false, help: dryRunMsg);
+  _parser.addFlag('verbose', abbr: 'v', negatable: false);
 
   var argResults;
   try {
@@ -23,20 +25,21 @@ List<String> processArgs(List<String> args) {
     printUsageAndExit(e.message, 0);
   }
 
-  if (argResults["help"]) printUsageAndExit(_parser);
+  if (argResults['help']) printUsageAndExit();
 
   dryRun = argResults['dry-run'];
+  verbose = argResults['verbose'];
   return argResults.rest;
 }
 
 void printUsageAndExit([String _msg, int exitCode = 1]) {
-  var msg = "Syncs angular.io example applications.";
+  var msg = 'Syncs angular.io example applications.';
   if (_msg != null) msg = _msg;
   print('''
 
 $msg.
 
-Usage: ${Platform.script} [options] <examplePath> <exampleRepository>
+Usage: ${Platform.script} [options] [<exampleName> | <examplePath> <exampleRepo>]
 
 ${_parser != null ? _parser.usage : ''}
 ''');

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+
+/// Global option
+bool dryRun = true;
+var _parser;
+
+/// Processes command line options and returns remaining arguments.
+List<String> processArgs(List<String> args) {
+  _parser = new ArgParser(allowTrailingOptions: true);
+
+  _parser.addFlag("help",
+      abbr: "h", negatable: false, help: "Shows usage information.");
+  const dryRunMsg = "Show which commands would be executed but make (almost) "
+      "no changes. (Only the temporary directory will be created and deleted.)";
+  _parser.addFlag("dry-run", abbr: "n", negatable: false, help: dryRunMsg);
+
+  var argResults;
+  try {
+    argResults = _parser.parse(args);
+  } on FormatException catch (e) {
+    printUsageAndExit(e.message, 0);
+  }
+
+  if (argResults["help"]) printUsageAndExit(_parser);
+
+  dryRun = argResults['dry-run'];
+  return argResults.rest;
+}
+
+void printUsageAndExit([String _msg, int exitCode = 1]) {
+  var msg = "Syncs angular.io example applications.";
+  if (_msg != null) msg = _msg;
+  print('''
+
+$msg.
+
+Usage: ${Platform.script} [options] <examplePath> <exampleRepository>
+
+${_parser != null ? _parser.usage : ''}
+''');
+  exit(exitCode);
+}

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -5,6 +5,7 @@ import 'package:args/args.dart';
 /// Global option
 bool dryRun = true;
 bool verbose = false;
+
 ArgParser _parser;
 
 /// Processes command line options and returns remaining arguments.

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:logging/logging.dart';
+import 'options.dart';
+
+export 'options.dart' show dryRun;
+
+final Logger _logger = new Logger('runner');
+
+Future<ProcessResult> run(String executable, List<String> arguments,
+    {String workingDirectory}) {
+  if (!dryRun)
+    return Process.run(executable, arguments,
+        workingDirectory: workingDirectory);
+
+  var message = "  > $executable ${arguments.join(' ')}";
+  if (workingDirectory != null) message += " ($workingDirectory)";
+  _logger.finest(message);
+  if (executable == 'git' && arguments[0] == 'clone') {
+    var path = arguments[2];
+    new Directory(path).createSync(recursive: true);
+  }
+  const int _bogusPid = 0;
+  const int _exitOk = 0;
+  return new Future.value(new ProcessResult(_bogusPid, _exitOk, null, null));
+}


### PR DESCRIPTION
- `dart_doc_syncer` now accepts one or two arguments. If one, it is taken as the example name from which the usual two argument path/URI are derived.
- `dart_doc_syncer --verbose` will give details of what operations it is doing.
- Tweak to generated README.md
