### PR TITLE
Ensure index.html base href is ok for gh-pages

### DIFF
--- a/lib/src/generate_doc.dart
+++ b/lib/src/generate_doc.dart
@@ -27,7 +27,7 @@ Future assembleDocumentationExample(Directory snapshot, Directory out,
   await Process.run('cp', ['-a', p.join(snapshot.path, '.'), out.path]);
 
   // Remove unimportant files that would distract the user.
-  await Process.run('rm', [p.join(out.path, '.analysis_options')]);
+  await Process.run('rm', ['-f', p.join(out.path, '.analysis_options')]);
 
   // Add the common styles file.
   await Process.run('cp', [

--- a/lib/src/generate_gh_pages.dart
+++ b/lib/src/generate_gh_pages.dart
@@ -1,10 +1,14 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
 import 'runner.dart' as Process; // TODO(chalin) tmp name to avoid code changes
 import 'options.dart';
+import 'util.dart';
+
+final Logger _logger = new Logger('generate_gh_pages');
 
 /// Returns the path to the folder where the application assets have been
 /// generated.
@@ -12,10 +16,17 @@ Future<String> generateApplication(
     Directory example, String exampleName) async {
   final applicationPath = p.join(workDirPath, '${exampleName}_app');
 
-  // Copy the application code into a seperate folder.
+  // Copy the application code into a separate folder.
   await Process.run('cp', ['-a', p.join(example.path, '.'), applicationPath]);
 
-  // Build the application assets into the 'build' folder.
+  _logger.fine(
+      'Adjust router <base href> in index.html so that it works under gh-pages');
+  await transformFile(
+      p.join(applicationPath, 'web/index.html'),
+      (content) => content.replaceAll(
+          '<base href="/">', '<base href="/$exampleName/">'));
+
+  _logger.fine("Build the application assets into the 'build' folder");
   await Process.run('pub', ['get'], workingDirectory: applicationPath);
   await Process.run('pub', ['build'], workingDirectory: applicationPath);
 

--- a/lib/src/generate_readme.dart
+++ b/lib/src/generate_readme.dart
@@ -84,7 +84,7 @@ If you find a problem with this sample's code, please open an
 
   final readmeFile = new File(p.join(path, 'README.md'));
   _logger.fine('Generating $readmeFile.');
-  await readmeFile.writeAsStringSync(readmeContent);
+  await readmeFile.writeAsString(readmeContent);
 }
 
 /// Holds metadata about the example application that is used to generate a

--- a/lib/src/git_documentation_updater.dart
+++ b/lib/src/git_documentation_updater.dart
@@ -88,13 +88,13 @@ class GitDocumentationUpdater implements DocumentationUpdater {
           outRepo.branch);
 
       if (updated || options.forceBuild) {
-        print("  Building app");
-        updated = updated ||
-            await __handleUpdate(
+        print('  Building app' + (options.forceBuild ? ' (force build)' : ''));
+        updated = await __handleUpdate(
                 () => _updateGhPages(outRepo, exampleName, commitMessage, push),
                 'App files have changed',
                 exampleName,
-                'gh-pages');
+                'gh-pages') ||
+            updated;
       } else {
         final msg = 'not built (to force use `--force-build`)';
         print("  $exampleName (gh-pages): $msg");

--- a/lib/src/git_repository.dart
+++ b/lib/src/git_repository.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
@@ -8,7 +7,8 @@ import 'runner.dart' as Process; // TODO(chalin) tmp name to avoid code changes
 import 'util.dart';
 
 class GitRepositoryFactory {
-  GitRepository create(String directory, [String branch = 'master']) => new GitRepository(directory, branch);
+  GitRepository create(String directory, [String branch = 'master']) =>
+      new GitRepository(directory, branch);
 }
 
 class GitRepository {
@@ -22,46 +22,39 @@ class GitRepository {
   Future cloneFrom(String repository) async {
     _logger.fine('Cloning $repository ($branch) into $directory.');
     dryRunMkDir(directory);
-    await _assertSuccess(() =>
-        Process.run('git', ['clone', '-b', branch, repository, directory]));
+    await _git(['clone', '-b', branch, repository, directory]);
   }
 
   /// Deletes all files in this git [directory].
   Future deleteAll() async {
     _logger.fine('Deleting all the repository content in $directory.');
-    await _assertSuccess(
-        () => Process.run('git', ['rm', '*'], workingDirectory: directory));
+    await _git(['rm', '*'], workingDirectory: directory);
   }
 
   /// Stages, commits with [message] and pushes local changes to origin for
   /// [directory].
   Future pushCurrent() async {
     _logger.fine('Pushing changes for $directory.');
-    await _assertSuccess(
-        () => Process.run('git', ['push'], workingDirectory: directory));
+    await _git(['push'], workingDirectory: directory);
   }
 
   /// Stages, commits with [message] and pushes local changes to origin for
   /// [directory].
   Future pushGhPages() async {
     _logger.fine('Pushing changes to gh-pages for $directory.');
-    await _assertSuccess(() => Process.run(
-        'git', ['push', '--set-upstream', 'origin', 'gh-pages'],
-        workingDirectory: directory));
+    await _git(['push', '--set-upstream', 'origin', 'gh-pages'],
+        workingDirectory: directory);
   }
 
   Future update({String message}) async {
     _logger.fine('Checkout $branch.');
-    await _assertSuccess(() => Process.run('git', ['checkout', branch],
-        workingDirectory: directory));
+    await _git(['checkout', branch], workingDirectory: directory);
 
     _logger.fine('Staging local changes for $directory.');
-    await _assertSuccess(
-        () => Process.run('git', ['add', '.'], workingDirectory: directory));
+    await _git(['add', '.'], workingDirectory: directory);
 
     _logger.fine('Committing changes for $directory.');
-    await _assertSuccess(() => Process.run('git', ['commit', '-m', message],
-        workingDirectory: directory));
+    await _git(['commit', '-m', message], workingDirectory: directory);
   }
 
   /// Clones the git [repository] into this [directory].
@@ -69,35 +62,27 @@ class GitRepository {
     _logger.fine('Checkout gh-pages.');
 
     try {
-      await _assertSuccess(() => Process.run(
-          'git', ['fetch', 'origin', 'gh-pages'],
-          workingDirectory: directory));
-      await _assertSuccess(() => Process.run('git', ['checkout', 'gh-pages'],
-          workingDirectory: directory));
+      await _git(['fetch', 'origin', 'gh-pages'], workingDirectory: directory);
+      await _git(['checkout', 'gh-pages'], workingDirectory: directory);
     } catch (e) {
       _logger.fine('Unable to fetch gh-pages: ${(e as GitException).message}');
       _logger.fine('Creating new --orphan gh-pages branch.');
-      await _assertSuccess(() => Process.run(
-          'git', ['checkout', '--orphan', 'gh-pages'],
-          workingDirectory: directory));
+      await _git(['checkout', '--orphan', 'gh-pages'],
+          workingDirectory: directory);
     }
 
     // Remove all files from old working tree.
     _logger.fine('Remove existing files from old working tree in $directory.');
-    await _assertSuccess(
-        () => Process.run('git', ['add', '.'], workingDirectory: directory));
-    await _assertSuccess(() =>
-        Process.run('git', ['rm', '-rf', '*'], workingDirectory: directory));
+    await _git(['add', '.'], workingDirectory: directory);
+    await _git(['rm', '-rf', '*'], workingDirectory: directory);
 
     // Copy the application assets into this folder.
     _logger.fine('Copy from $sourcePath to $directory.');
     await Process.run('cp', ['-a', p.join(sourcePath, '.'), directory]);
 
     _logger.fine('Committing gh-pages changes for $directory.');
-    await _assertSuccess(
-        () => Process.run('git', ['add', '.'], workingDirectory: directory));
-    await _assertSuccess(() => Process.run('git', ['commit', '-m', message],
-        workingDirectory: directory));
+    await _git(['add', '.'], workingDirectory: directory);
+    await _git(['commit', '-m', message], workingDirectory: directory);
   }
 
   /// Returns the commit hash at HEAD.
@@ -105,8 +90,7 @@ class GitRepository {
     if (Process.options.dryRun) return new Future.value('COMMIT_HASH_CODE');
 
     final args = "rev-parse${short ? ' --short' : ''} HEAD".split(' ');
-    final hash = await _assertSuccess(
-        () => Process.run('git', args, workingDirectory: directory));
+    final hash = await _git(args, workingDirectory: directory);
 
     return hash.split('\n')[0].trim();
   }
@@ -123,13 +107,10 @@ class GitException implements Exception {
   }
 }
 
-/// Throws if the exitCode returned by [command] is not 0.
-Future<String> _assertSuccess(Future<ProcessResult> command()) async {
-  final r = await command();
-  if (r.exitCode != 0) {
-    final message = r.stderr.isEmpty ? r.stdout : r.stderr;
-    throw new GitException(message);
-  }
-
+Future<String> _git(List<String> arguments,
+    {String workingDirectory, Exception mkException(String msg)}) async {
+  final r = await Process.run('git', arguments,
+      workingDirectory: workingDirectory,
+      mkException: (msg) => new GitException(msg));
   return r.stdout;
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -21,3 +21,12 @@ Future dryRunMkDir(String path) async {
   var dir = new Directory(path);
   return await dir.create();
 }
+
+/// Read [path] as a string, apply [transformer] and write back the result.
+Future<Null> transformFile(String path, transformer(dynamic content)) async {
+  _logger.fine('  Transform file $path');
+  if (options.dryRun) return new Future.value();
+
+  File file = new File(path);
+  await file.writeAsString(transformer(await file.readAsString()));
+}


### PR DESCRIPTION
- generate_gh_pages: transforms <base href> in index.html as necessary.

Other changes include:
- generate_doc: have rm ignore situation where file doesn’t exist.
- generate_readme: await for async write not sync.
- git_documentation_updater: fixed issue which sometimes required a
  `—force-build` option to be included when none should have been needed.
- git_repository: defined local _git() command to simplify code.
- runner: now uniforming reporting exception when command returns
  nonzero exit code.

Fixes https://github.com/angular/angular.io/issues/1608
