### PR TITLE
Generate cleaner sample repos w/o prose-only files, etc

### DIFF
--- a/lib/src/generate_doc.dart
+++ b/lib/src/generate_doc.dart
@@ -37,7 +37,7 @@ Future assembleDocumentationExample(Directory snapshot, Directory out,
 
   // Remove source files used solely in support of the prose.
   final targetFiles =
-      whitelist.map((ext) => '-name "*_[0-9]$ext"').join(' -o ');
+      whitelist.map((ext) => '-name *_[0-9]$ext').join(' -o ');
   await Process.run('find',
       [out.path]..addAll('( $targetFiles ) -exec rm -f {} +'.split(' ')));
 

--- a/lib/src/generate_doc.dart
+++ b/lib/src/generate_doc.dart
@@ -14,6 +14,8 @@ final Logger _logger = new Logger('update_doc_repo');
 final String _basePath = p.dirname(Platform.script.path);
 final String _defaultAssetsPath = p.join(_basePath, "../default_assets");
 
+const whitelist = const ['.css', '.dart', '.html', '.yaml'];
+
 /// Generates a clean documentation application folder based on the raw content
 /// at [snaphsot].
 Future assembleDocumentationExample(Directory snapshot, Directory out,
@@ -27,7 +29,17 @@ Future assembleDocumentationExample(Directory snapshot, Directory out,
   await Process.run('cp', ['-a', p.join(snapshot.path, '.'), out.path]);
 
   // Remove unimportant files that would distract the user.
-  await Process.run('rm', ['-f', p.join(out.path, '.analysis_options')]);
+  await Process.run('rm', [
+    '-f',
+    p.join(out.path, '.analysis_options'),
+    p.join(out.path, 'example-config.json')
+  ]);
+
+  // Remove source files used solely in support of the prose.
+  final targetFiles =
+      whitelist.map((ext) => '-name "*_[0-9]$ext"').join(' -o ');
+  await Process.run('find',
+      [out.path]..addAll('( $targetFiles ) -exec rm -f {} +'.split(' ')));
 
   // Add the common styles file.
   await Process.run('cp', [
@@ -61,7 +73,6 @@ Future _removeDocTagsFromApplication(String path) async {
 
 /// Rewrites the [file] by filtering out the documentation tags.
 Future _removeDocTagsFromFile(File file) async {
-  const whitelist = const ['.html', '.dart', '.yaml'];
   if (whitelist.every((String e) => !file.path.endsWith(e))) return null;
 
   final content = await file.readAsString();

--- a/lib/src/generate_readme.dart
+++ b/lib/src/generate_readme.dart
@@ -59,8 +59,9 @@ Welcome to the example application used in angular.io/dart's
 
 $liveExampleSection
 
-1. Clone this repo.
-2. Download the dependencies:
+1. Clone or [download][] this repo.
+   [download]: //github.com/angular-examples/${syncData.name}/archive/master.zip
+2. Get the dependencies:
 
   `pub get`
 3. Launch a development server:

--- a/lib/src/remove_doc_tags.dart
+++ b/lib/src/remove_doc_tags.dart
@@ -10,7 +10,14 @@ bool _isNotDocTagComment(String line) => !_isDocTagComment(line);
 
 /// Returns true if [line] is a comment line with a doc tag.
 bool _isDocTagComment(String line) =>
-    _isComment(line) && _docTags.any((String tag) => line.contains(tag));
+    _isComment(line) && _docTags.any((String tag) => line.contains(tag)) ||
+    _isCssDocTagComment(line);
+
+/// Returns true if [line] is a CSS comment line with a doc tag.
+final _anyDocTag = _docTags.join('|');
+final cssDocTag =
+    new RegExp(r'^\s*/\*\s*(' + _anyDocTag + r')[\s\w_,]*\*/\s*$');
+bool _isCssDocTagComment(String line) => cssDocTag.hasMatch(line);
 
 /// Returns true if [line] starts with any of the prefixes indicating the start
 /// of a doc tag comment.


### PR DESCRIPTION
- Delete prose-only source files.
- Delete `example-config.json` (e2e test trigger file used via angular.io repo only).
- Remove `docregion` tags from .css files.

Also:
- Add direct download link to `README.md` template.
