### PR TITLE
Support setting <base href> even when set dynamically

### DIFF
--- a/lib/src/generate_gh_pages.dart
+++ b/lib/src/generate_gh_pages.dart
@@ -19,12 +19,19 @@ Future<String> generateApplication(
   // Copy the application code into a separate folder.
   await Process.run('cp', ['-a', p.join(example.path, '.'), applicationPath]);
 
-  _logger.fine(
-      'Adjust router <base href> in index.html so that it works under gh-pages');
+  _logger
+      .fine('Adjust <base href> in index.html so that app runs under gh-pages');
+
+  // If the `index.html` either statically or dynamically sets <base href>
+  // replace that element by a <base href> appropriate for serving via GH pages.
+  final baseHrefEltOrScript = new RegExp(r'<base href="/">|'
+      r'<script>(\s|[^<])+<base href(\s|[^<]|<[^/])+</script>');
+
+  final appBaseHref = '<base href="/$exampleName/">';
   await transformFile(
       p.join(applicationPath, 'web/index.html'),
-      (content) => content.replaceAll(
-          '<base href="/">', '<base href="/$exampleName/">'));
+      (String content) =>
+          content.replaceFirst(baseHrefEltOrScript, appBaseHref));
 
   _logger.fine("Build the application assets into the 'build' folder");
   await Process.run('pub', ['get'], workingDirectory: applicationPath);


### PR DESCRIPTION
Some of the doc samples now set the `<base href>` dynamically via a `<script>` -- e.g., see https://github.com/dart-lang/site-webdev/pull/398/files#diff-7bccda254a26ff8b96521b2c544503d2R4. This PR adjusts the DDS so that it can replace such a `<script>` with an appropriate (static) `<base href="/exampleName">`.

Contributes to https://github.com/dart-lang/site-webdev/issues/358

cc @kwalrath 

----

Tested it on the (new) `quickstart` and `architecture` samples and it works as expected. I.e., there is no change to the latter, and the former becomes:
```html
<!DOCTYPE html><html><head>
    <base href="/quickstart/">

    <title>Hello Angular</title>
    <meta charset="utf-8">
...
```
changed from:
```html
<!DOCTYPE html>
<html>
  <head>
    <script>
        // WARNING: DO NOT set the <base href> like this in production!
        // Details: https://webdev.dartlang.org/angular/guide/router
        (function () {
            // App being served out of web folder (like WebStorm does)?
            var match = document.location.pathname.match(/^\/[_\w]+\/web\//);
            var href = match ? match[0] : '/';
            document.write('<base href="' + href + '" />');
        }());
    </script>

    <title>Hello Angular</title>
    <meta charset="utf-8">
...
```