### PR TITLE
Add `favicon.png` from boilerplate folder to all ng samples

### DIFF
--- a/lib/src/generate_doc.dart
+++ b/lib/src/generate_doc.dart
@@ -44,8 +44,9 @@ Future assembleDocumentationExample(Directory snapshot, Directory out,
   final boilerPlatePath =
       p.join(angularDirectory.path, docExampleDirRoot, '_boilerplate');
   await Process.run('cp', [
+    p.join(boilerPlatePath, 'favicon.png'),
     p.join(boilerPlatePath, 'styles.css'),
-    p.join(out.path, 'web/styles.css')
+    p.join(out.path, 'web')
   ]);
 
   // Clean the application code


### PR DESCRIPTION
Contributes to https://github.com/dart-lang/site-webdev/issues/760