### PR TITLE
Add a `build-info.json` file to the built apps

### DIFF
--- a/lib/src/generate_gh_pages.dart
+++ b/lib/src/generate_gh_pages.dart
@@ -63,7 +63,8 @@ void excludeTmpBuildFiles(Directory exampleRepo, Iterable<String> appDirPaths) {
   }
 }
 
-Future createBuildInfoFile(String pathToWebFolder, String exampleName, String commitHash) async {
+Future createBuildInfoFile(
+    String pathToWebFolder, String exampleName, String commitHash) async {
   final buildInfoFile = new File(p.join(pathToWebFolder, buildInfoFileName));
 
   // We normalize the build timestamp to TZ=US/Pacific, which is easier
@@ -73,7 +74,8 @@ Future createBuildInfoFile(String pathToWebFolder, String exampleName, String co
 
   final json = {
     'build-time': date.isNotEmpty ? date.trim() : new DateTime.now(),
-    'commit-sha': 'https://github.com/angular-examples/$exampleName/commit/$commitHash'
+    'commit-sha':
+        'https://github.com/angular-examples/$exampleName/commit/$commitHash'
   };
   buildInfoFile.writeAsStringSync(JSON.encode(json));
 }

--- a/lib/src/generate_gh_pages.dart
+++ b/lib/src/generate_gh_pages.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
+import 'options.dart';
 import 'runner.dart' as Process; // TODO(chalin) tmp name to avoid code changes
 import 'util.dart';
 
@@ -47,7 +49,7 @@ build/
 pubspec.lock
 ''';
 
-/// Files created when the app was build should be ignored.
+/// Files created when the app was built should be ignored.
 void excludeTmpBuildFiles(Directory exampleRepo, Iterable<String> appDirPaths) {
   final excludeFilePath = p.join(exampleRepo.path, '.git', 'info', 'exclude');
   final excludeFile = new File(excludeFilePath);
@@ -59,4 +61,19 @@ void excludeTmpBuildFiles(Directory exampleRepo, Iterable<String> appDirPaths) {
     _logger.fine('  > Adding tmp build files to $excludeFilePath');
     excludeFile.writeAsStringSync('$excludeFileAsString\n$excludes\n');
   }
+}
+
+Future createBuildInfoFile(String pathToWebFolder, String exampleName, String commitHash) async {
+  final buildInfoFile = new File(p.join(pathToWebFolder, buildInfoFileName));
+
+  // We normalize the build timestamp to TZ=US/Pacific, which is easier
+  // to do using the OS date command. Failing that use DateTime.now().
+  final r = await Process.run('date', [], environment: {'TZ': 'US/Pacific'});
+  final date = r.stdout as String;
+
+  final json = {
+    'build-time': date.isNotEmpty ? date.trim() : new DateTime.now(),
+    'commit-sha': 'https://github.com/angular-examples/$exampleName/commit/$commitHash'
+  };
+  buildInfoFile.writeAsStringSync(JSON.encode(json));
 }

--- a/lib/src/git_documentation_updater.dart
+++ b/lib/src/git_documentation_updater.dart
@@ -27,12 +27,12 @@ class GitDocumentationUpdater implements DocumentationUpdater {
     int updateCount = 0;
     try {
       final angularRepository = await _cloneWebdevRepoIntoWorkDir();
-      final files = (await new Directory(angularRepository.dirPath)
+      final files = await new Directory(angularRepository.dirPath)
           .list(recursive: true)
           .where(
               (e) => e is File && p.basename(e.path) == exampleConfigFileName)
-          .toList())
-          ..sort((e1, e2) => e1.path.compareTo(e2.path));
+          .toList();
+      files.sort((e1, e2) => e1.path.compareTo(e2.path));
       for (var e in files) {
         var dartDir =
             p.dirname(e.path).substring(angularRepository.dirPath.length);
@@ -220,8 +220,7 @@ class GitDocumentationUpdater implements DocumentationUpdater {
     }
   }
 
-  Future _buildApp(
-      Directory dir, String exampleName, String commitHash) async {
+  Future _buildApp(Directory dir, String exampleName, String commitHash) async {
     await buildApp(dir);
     var href = '/$exampleName/' +
         (options.ghPagesAppDir.isEmpty ? '' : '${options.ghPagesAppDir}/');

--- a/lib/src/git_repository.dart
+++ b/lib/src/git_repository.dart
@@ -110,6 +110,17 @@ class GitRepository {
 
     _logger.fine('Committing gh-pages changes for $dirPath.');
     await _git(['add', '.'], workingDirectory: dirPath);
+    final status = await _git(['status', '--short'], workingDirectory: dirPath);
+    final statusLines = status.split('\n')
+      ..removeWhere((statusLine) =>
+          statusLine.isEmpty ||
+          statusLine.startsWith('M') && statusLine.contains(buildInfoFileName));
+    if (statusLines.length == 0) {
+      final msg =
+          'At most the $buildInfoFileName file has changed: nothing to commit';
+      _logger.fine('  $msg');
+      throw msg;
+    }
     await _git(['commit', '-m', message], workingDirectory: dirPath);
   }
 
@@ -131,11 +142,6 @@ class GitRepository {
           workingDirectory: dirPath);
       await delete();
     }
-  }
-
-  bool _isGhPagesException(ProcessResult r) {
-    final stderr = r.stderr;
-    return stderr is! String || stderr.contains("");
   }
 
   /// Returns the commit hash at HEAD.

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -28,6 +28,7 @@ class Options {
 Options options = new Options();
 
 // TODO: make these configurable? (with defaults as given)
+const buildInfoFileName = 'build-info.json';
 const dartDocHostUri = 'https://webdev.dartlang.org';
 const exampleConfigFileName = '.docsync.json';
 const tempFolderNamePrefix = 'dds-';

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -10,7 +10,8 @@ final Logger _logger = new Logger('runner');
 Exception newException(String msg) => new Exception(msg);
 
 Future<ProcessResult> run(String executable, List<String> arguments,
-    {String workingDirectory,
+    {Map<String, String> environment,
+    String workingDirectory,
     bool isException(ProcessResult r),
     Exception mkException(String msg): newException}) async {
   var cmd = "$executable ${arguments.join(' ')}";
@@ -19,7 +20,7 @@ Future<ProcessResult> run(String executable, List<String> arguments,
 
   if (!options.dryRun) {
     final r = await Process.run(executable, arguments,
-        workingDirectory: workingDirectory);
+        workingDirectory: workingDirectory, environment: environment);
     if (r.exitCode == 0 && (isException == null || !isException(r))) return r;
     // _logger.info('ERROR running: $cmd. Here are stderr and stdout:');
     // _logger.info(r.stderr);

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -24,7 +24,7 @@ Future dryRunMkDir(String path) async {
 }
 
 /// Read [path] as a string, apply [transformer] and write back the result.
-Future<Null> transformFile(String path, transformer(dynamic content)) async {
+Future<Null> transformFile(String path, String transformer(String content)) async {
   _logger.fine('  Transform file $path');
   if (options.dryRun) return new Future.value();
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -24,7 +24,8 @@ Future dryRunMkDir(String path) async {
 }
 
 /// Read [path] as a string, apply [transformer] and write back the result.
-Future<Null> transformFile(String path, String transformer(String content)) async {
+Future<Null> transformFile(
+    String path, String transformer(String content)) async {
   _logger.fine('  Transform file $path');
   if (options.dryRun) return new Future.value();
 


### PR DESCRIPTION
- Fixes https://github.com/dart-lang/site-webdev/issues/1004
- Only commit app (gh-pages) if at least one file other than the build file has changed.
- Also sorts example names list when matching multiple examples.

Here is an example of a committed build-info.json file:
- http://angular-examples.github.io/forms/4/build-info.json